### PR TITLE
Fix: No text sending "opendrawer" command

### DIFF
--- a/src/jposbox/Web.java
+++ b/src/jposbox/Web.java
@@ -353,7 +353,7 @@ public class Web {
                     P.add(s);
                     P.print(PosBoxFrame.ComboPrinter1.getSelectedItem().toString(), 1,"7");
                 }
-                if (text!=null){
+                else if (text!=null){
                     PosPrinter P= new PosPrinter();
                     P.html=true;
                     P.P=text;


### PR DESCRIPTION
The opendrawer command is writing the text "opendrawer", adding a ELSE resolve de issue. 